### PR TITLE
Solucionado error KillerPanelPrincipal.

### DIFF
--- a/src/gameRoom/KillerPanelConectar.form
+++ b/src/gameRoom/KillerPanelConectar.form
@@ -19,6 +19,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,44,0,0,1,-112"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout">

--- a/src/gameRoom/KillerPanelConectar.java
+++ b/src/gameRoom/KillerPanelConectar.java
@@ -5,6 +5,8 @@
  */
 package gameRoom;
 
+import game.KillerGame;
+
 
 
 /**
@@ -20,6 +22,7 @@ public class KillerPanelConectar extends javax.swing.JPanel {
      
      //Variables jPanel
      KillerPanelPrincipal kpp;
+     private KillerGame kg;
      
      
     /**
@@ -28,6 +31,7 @@ public class KillerPanelConectar extends javax.swing.JPanel {
     public KillerPanelConectar(KillerPanelPrincipal kpp) {
         this.kpp = kpp;
         initComponents();
+        kg = kpp.getKg();
     }
     
     public KillerPanelConectar getKillerPanelConectar(){
@@ -137,11 +141,10 @@ public class KillerPanelConectar extends javax.swing.JPanel {
         portIzq = Integer.parseInt(jTextFieldPortIzq.getText());
         ipDer = jTextFieldIpDer.getText();
         portDer = Integer.parseInt(jTextFieldPortDer.getText());
-        kg.setPortPrev();
-        kg.setPortNext();
-        kg.setIpPrev();
-        kg.setIpNext();
-
+        kg.setPortPrev(portIzq);
+        kg.setPortNext(portDer);
+        kg.setIpPrev(ipIzq);
+        kg.setIpNext(ipDer);
     }//GEN-LAST:event_jButton2ActionPerformed
 
     private void jButton1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton1ActionPerformed

--- a/src/gameRoom/KillerPanelPrincipal.java
+++ b/src/gameRoom/KillerPanelPrincipal.java
@@ -60,6 +60,10 @@ public class KillerPanelPrincipal extends javax.swing.JPanel {
         return this;
     }
     
+    public KillerGame getKg(){
+        return this.kg;
+    }
+    
     public void setButtonPlay(Boolean aux){
         if (aux == true) {
             jButtonJugar.setEnabled(true);


### PR DESCRIPTION
Añadido Getter en KillerPanelPrincipal para obtener objeto KillerGame
en KillerPanelConectar.
Pasados por parametro valores de puerto e Ip que olvide.